### PR TITLE
Update dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every month
-      interval: "monthly"
+      interval: "yearly"
+    ignore: # only update minor or major version changes
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     target-branch: "slides"
     groups:
       actions:


### PR DESCRIPTION
Change GitHub Actions update interval to yearly and ignore patch updates.